### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+eyed3 (0.9.7-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Remove 2 maintscript entries from 2 files.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 18 Mar 2023 15:57:44 -0000
+
 eyed3 (0.9.7-1) unstable; urgency=low
 
   * New upstream version

--- a/debian/eyed3.maintscript
+++ b/debian/eyed3.maintscript
@@ -1,1 +1,0 @@
-symlink_to_dir /usr/share/doc/eyed3 python-eyed3 0.8.4-2~

--- a/debian/python3-eyed3.maintscript
+++ b/debian/python3-eyed3.maintscript
@@ -1,1 +1,0 @@
-symlink_to_dir /usr/share/doc/python3-eyed3 python-eyed3 0.8.4-2~


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in first set of .debs but not in second
    -rwxr-xr-x  root/root   DEBIAN/postrm
    -rwxr-xr-x  root/root   DEBIAN/preinst

No differences were encountered between the control files of package \*\*eyed3\*\*

No differences were encountered between the control files of package \*\*python3-eyed3\*\*

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/0617cdbf-49bf-4178-917b-62babb4cc993/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/0617cdbf-49bf-4178-917b-62babb4cc993/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/0617cdbf-49bf-4178-917b-62babb4cc993.